### PR TITLE
Change the detect script from Ruby to Bash

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env bash
 
-puts "GSL"
+echo "GSL"
 exit 0


### PR DESCRIPTION
The detect script uses #!/usr/bin/env ruby but Ruby isn't installed yet on Heroku-24 until the Ruby buildpack runs.